### PR TITLE
Fixed the link to `codetector1374`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you want to argue with me on whether it's a REAL BONA FIDE CVE, please feel f
 
 ## Backstory
 
-Stuck in quarantine, my roomates ([Pear0](https://github.com/Pear0), [Codetector](github.com/codetector1374)) and I were fooling around on Pear0's new Asrock motherboard. The bright red LEDs were extremely annoying and it was not possible to configure them on Linux. Thus our plan was to reverse the Windows driver that controlled it and replicate the I/O operations on Linux.
+Stuck in quarantine, my roomates ([Pear0](https://github.com/Pear0), [Codetector](https://github.com/codetector1374)) and I were fooling around on Pear0's new Asrock motherboard. The bright red LEDs were extremely annoying and it was not possible to configure them on Linux. Thus our plan was to reverse the Windows driver that controlled it and replicate the I/O operations on Linux.
 
 Long story short, it didn't take long until we realized the driver is literally just a generic driver granting arbitrary read/write access to anything. This includes control registers like CR3, CR4, physical memory, etc. Drivers like this are [intended for use as a debugging tool](http://rweverything.com/) and the vendor's website clearly states so.
 


### PR DESCRIPTION
Before, the link was `https://github.com/stong/CVE-2020-15368/blob/master/github.com/codetector1374`